### PR TITLE
[#185136309] Verbesserungen des Molecule Workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ Upstream Ubuntu 20.04 / 22.04 Docker Container with following extensions:
 ## CI Workflow
 To use this action in your repo you can create a new Github Workflow with the example [molecule.yml](examples/molecule.yml)
 
+This will test your role against the following Ansible Scenarios:
+- `ansible_current`
+- `ansible_next`
+- `ansible_latest`
+
+Used Ansible Version for these scenarios are defined in [action.yml](examples/action.yml), but can be overridden. Leave `ansible_scenario` unset for simple tests against latest ansible and molecule version. 
+
 # Configuration
 ## Only Lint, no Molecule Tests
 
@@ -83,8 +90,8 @@ If you want to include tests which are not mandatory, mark them as `experimental
   become: true
 
   pre_tasks:
-    - name: update APT Cache
-      apt:
+    - name: Update APT Cache
+      ansible.builtin.apt:
         update_cache: yes
         cache_valid_time: 600
       register: result
@@ -93,13 +100,13 @@ If you want to include tests which are not mandatory, mark them as `experimental
 
     # skip idempotence tests
     - name: Include Example install role
-      include_role:
+      ansible.builtin.include_role:
         name: example
       when: "'molecule-idempotence-notest' not in ansible_skip_tags"
 
   tasks:
     - name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
-      include_role:
+      ansible.builtin.include_role:
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
 ```
 
@@ -121,8 +128,8 @@ Create `molecule/default/converge.yml` inside the repository with following cont
   become: true
 
   pre_tasks:
-    - name: update APT Cache
-      apt:
+    - name: Update APT Cache
+      ansible.builtin.apt:
         update_cache: yes
         cache_valid_time: 600
       register: result
@@ -132,7 +139,7 @@ Create `molecule/default/converge.yml` inside the repository with following cont
   tasks:
     # skip idempotence tests
     - name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
-      include_role:
+      ansible.builtin.include_role:
         name: "{{ lookup('env', 'MOLECULE_PROJECT_DIRECTORY') | basename }}"
       tags:
         - molecule-idempotence-notest
@@ -145,7 +152,7 @@ Tag the task with `molecule-idempotence-notest`:
 ```yaml
 # skip idempotence tests
 - name: Not idempotent task
-  command: "echo not-idempotent"
+  ansible.builtin.command: "echo not-idempotent"
   tags:
     - molecule-idempotence-notest
 ```
@@ -161,7 +168,7 @@ Create `molecule/default/converge.yml` inside the repository with following cont
   tasks:
     # skip idempotence tests
     - name: Include Example install role
-      include_role:
+      ansible.builtin.include_role:
         name: example
       when: "'molecule-idempotence-notest' not in ansible_skip_tags"
 ...

--- a/action.yml
+++ b/action.yml
@@ -89,15 +89,16 @@ runs:
 
     # PINs:
     # - urllib3<2 https://github.com/docker/docker-py/issues/3113
+    # - molecule-docker==1.1.0 für ansible-core < 2.12 versionen: https://github.com/ansible-community/molecule-docker/pull/156
 
     - name: Install software for 'ansible current' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_current' }}"
-      run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_current_version }}' 'molecule<5' molecule[docker] docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
+      run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_current_version }}' 'molecule<5' 'molecule-docker==1.1.0' docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
       shell: bash
 
     - name: Install software for 'ansible next' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_next' }}"
-      run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_next_version }}' 'molecule<5' molecule[docker] docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
+      run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_next_version }}' 'molecule<5' 'molecule-docker==1.1.0' docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
       shell: bash
 
     - name: Install software for 'ansible latest' scenario

--- a/action.yml
+++ b/action.yml
@@ -91,17 +91,17 @@ runs:
     # - urllib3<2 https://github.com/docker/docker-py/issues/3113
     # - molecule-docker==1.1.0 für ansible-core < 2.12 versionen: https://github.com/ansible-community/molecule-docker/pull/156
 
-    - name: Install software for 'ansible current' scenario
+    - name: Install software for 'ansible_current' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_current' }}"
       run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_current_version }}' 'molecule<5' 'molecule-docker==1.1.0' docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
       shell: bash
 
-    - name: Install software for 'ansible next' scenario
+    - name: Install software for 'ansible_next' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_next' }}"
       run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_next_version }}' 'molecule<5' 'molecule-docker==1.1.0' docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
       shell: bash
 
-    - name: Install software for 'ansible latest' scenario
+    - name: Install software for 'ansible_latest' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_latest' }}"
       run: pip install 'ansible${{ inputs.ansible_version }}' 'molecule${{ inputs.molecule_version }}' molecule-plugins[docker] docker netaddr jmespath dnspython 'Jinja2${{ inputs.jinja2_version }}' 'urllib3<2'
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
       shell: bash
 
     - name: Install collections from collections.yml
-      if: "${{ inputs.scenario != '' }}"
+      if: "${{ inputs.ansible_scenario != '' }}"
       run: ansible-galaxy install -r git_molecule/requirements/collections_${{ inputs.ansible_scenario }}.yml
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -115,13 +115,17 @@ runs:
       run: pip list
       shell: bash
 
+    - name: Install collections from collections.yml
+      if: "${{ inputs.ansible_scenario != '' }}"
+      run: ansible-galaxy install -r git_molecule/requirements/collections_${{ inputs.ansible_scenario }}.yml
+      shell: bash
+
     - name: Print molecule version infos
       run: molecule --version
       shell: bash
 
-    - name: Install collections from collections.yml
-      if: "${{ inputs.ansible_scenario != '' }}"
-      run: ansible-galaxy install -r git_molecule/requirements/collections_${{ inputs.ansible_scenario }}.yml
+    - name: Print installed ansible collections
+      run: ansible-galaxy collection list
       shell: bash
 
     - name: Run Molecule tests

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,7 @@ runs:
       with:
         repository: Rheinwerk/molecule
         path: 'git_molecule'
+        ref: v1
 
     - name: Set up Python 3
       uses: actions/setup-python@v4
@@ -75,14 +76,8 @@ runs:
       env:
         MOLECULE_SCENARIO_NAME: "${{ inputs.molecule_scenario }}"
 
-    - name: Update Molecule inventory if tests directory does not exist
-      run: if [[ "$TEST_TYPE" == "unit" || "$TEST_TYPE" == "destroy" ]] && [[ ! -f "${GITHUB_WORKSPACE}/tests/vars.yml" ]]; then yq -i 'del(.provisioner.inventory)' ${GITHUB_WORKSPACE}/molecule/default/molecule.yml; fi
-      shell: bash
-      env:
-        TEST_TYPE: "${{ inputs.test_type }}"
-
-    - name: Sync test vars to group_vars when exists
-      run: if [[ "$TEST_TYPE" == "unit" || "$TEST_TYPE" == "destroy" ]] && [[ -f "${GITHUB_WORKSPACE}/tests/vars.yml" ]]; then mkdir -p ${GITHUB_WORKSPACE}/group_vars/all/ && rsync -aP ${GITHUB_WORKSPACE}/tests/ ${GITHUB_WORKSPACE}/group_vars/all/; fi
+    - name: Sync test vars
+      run: if [[ "$TEST_TYPE" == "unit" ]] && [[ -f "${GITHUB_WORKSPACE}/tests/vars.yml" ]]; then mkdir -p ${GITHUB_WORKSPACE}/molecule/default/group_vars/all/ && rsync -aP ${GITHUB_WORKSPACE}/tests/vars.yml ${GITHUB_WORKSPACE}/molecule/default/group_vars/all/test_vars.yml; fi
       shell: bash
       env:
         TEST_TYPE: "${{ inputs.test_type }}"

--- a/dockerfiles/Ubuntu
+++ b/dockerfiles/Ubuntu
@@ -48,5 +48,4 @@ RUN apt-get update \
 # Fix potential UTF-8 errors with ansible-test.
 RUN locale-gen en_US.UTF-8
 
-VOLUME ["/sys/fs/cgroup", "/tmp", "/run"]
 CMD ["/lib/systemd/systemd"]

--- a/examples/molecule.yml
+++ b/examples/molecule.yml
@@ -33,7 +33,7 @@ jobs:
           cmd: yq ".galaxy_info.min_ansible_container_version" ${GITHUB_WORKSPACE}/meta/main.yml
 
   molecule:
-    name: Molecule for Ansible ${{ matrix.ansible_version }} / ${{ matrix.distro }} / Python ${{ matrix.python_version }}
+    name: Molecule for Ansible ${{ matrix.ansible_scenario }} / ${{ matrix.distro }} / Python ${{ matrix.python_version }}
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     needs: lint
@@ -43,23 +43,17 @@ jobs:
       matrix:
         include:
           - distro: ubuntu-20.04
+            ansible_scenario: ansible_current
             test_type: unit
-            ansible_version: '>=2.9, <2.10'
-            jinja2_version: '<3.1'
             python_version: '3.8'
             experimental: false
           - distro: ubuntu-20.04
-            test_type: unit
-            ansible_version: '>=2.10, <2.11'
-            jinja2_version: '<3.1'
-            python_version: '3.8'
-            experimental: false
-          - distro: ubuntu-20.04
+            ansible_scenario: ansible_next
             test_type: unit
             python_version: '3.8'
-            jinja2_version: '<3.1'
             experimental: true
           - distro: ubuntu-22.04
+            ansible_scenario: ansible_latest
             test_type: unit
             python_version: '3.10'
             experimental: true
@@ -68,7 +62,6 @@ jobs:
       - uses: Rheinwerk/molecule@v1
         with:
           distro: ${{ matrix.distro }}
+          ansible_scenario: ${{ matrix.ansible_scenario }}
           test_type: ${{ matrix.test_type }}
-          ansible_version: ${{ matrix.ansible_version }}
-          jinja2_version: ${{ matrix.jinja2_version }}
           python_version: ${{ matrix.python_version }}

--- a/scenarios/docker/molecule.yml
+++ b/scenarios/docker/molecule.yml
@@ -6,12 +6,19 @@ driver:
 platforms:
   - name: ${CI_HOSTNAME}-${CI_PROJECT_NAME_MOLECULE}-${CI_JOB_ID}
     image: ghcr.io/rheinwerk/molecule:${MOLECULE_DISTRO}
-    command: ${MOLECULE_DOCKER_COMMAND:-"/lib/systemd/systemd"}
     pre_build_image: true
     privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-    cgroupns_mode: host
+    cgroup_parent: docker.slice
+    cgroupns_mode: private
+    override_command: false
+    capabilities:
+      - SYS_ADMIN
+    security_opts:
+      - seccomp=unconfined
+    tmpfs:
+      - /run
+      - /tmp
+      - /run/lock
 provisioner:
   name: ansible
   config_options:

--- a/scenarios/docker/molecule.yml
+++ b/scenarios/docker/molecule.yml
@@ -26,9 +26,6 @@ provisioner:
       stdout_callback: yaml
     diff:
       always: true
-  inventory:
-    links:
-      group_vars: ${GITHUB_WORKSPACE}/group_vars/
   playbooks:
     converge: ${MOLECULE_CONVERGE_PLAYBOOK:-converge.yml}
   log: True


### PR DESCRIPTION
- Die genutzt Github Action soll ähnlich wie unsere Infra CI 3 mögliche Ansible versionen als Szenario implementieren, wodurch wir nur an zentraler Stelle die Ansible Version ändern und diese Änderung an alle Repos propagiert wird, welche diesen Github Workflow nutzen 

- Überarbeitung der Logik für das einbinden von Variablen für Testläufe mittels `molecule/default/group_vars/all/`

- Fix von Fehlern die aufgrund von cgroupv2 entstehen: https://github.com/geerlingguy/docker-ubuntu2004-ansible/issues/18

- Installiere Ansible Collections, welche auch im Baseimage verwendet werden für die aktuelle Ansible Version