### PR TITLE
[#185332448] CI: Nutze Ansibe Core 2.13, 2.14 + latest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,10 +6,10 @@ author: Michael Schmitz
 inputs:
   ansible_current_version:
     description: Ansible version to use for 'ansible_current' scenario
-    default: '==2.10.7'
+    default: '==2.13.*'
   ansible_next_version:
     description: Ansible version to use for 'ansible_next' scenario
-    default: '==3'
+    default: '==2.14.*'
   ansible_scenario:
     description: 'Predefined ansible versions: ansible_current, ansible_next, ansible_latest'
     default: ''
@@ -28,8 +28,11 @@ inputs:
   python_version:
     description: Python version to use
     default: '3.x'
+  jinja2_current_version:
+    description: Jinaj2 version to use for 'ansible_current' scenario
+    default: '==3.1.2'
   jinja2_version:
-    description: Jinaj2 version to use
+    description: Jinaj2 version to use, leave empty for newest
     default: ''
   test_type:
     description: 'Choose between: unit'
@@ -82,28 +85,24 @@ runs:
       env:
         TEST_TYPE: "${{ inputs.test_type }}"
 
-    # PINs:
-    # - urllib3<2 https://github.com/docker/docker-py/issues/3113
-    # - molecule-docker==1.1.0 für ansible-core < 2.12 versionen: https://github.com/ansible-community/molecule-docker/pull/156
-
     - name: Install software for 'ansible_current' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_current' }}"
-      run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_current_version }}' 'molecule<5' 'molecule-docker==1.1.0' docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
+      run: pip install 'ansible-core${{ inputs.ansible_current_version }}' 'molecule${{ inputs.molecule_version }}' molecule-plugins[docker] docker netaddr jmespath dnspython 'Jinja2${{ inputs.jinja2_current_version }}'
       shell: bash
 
     - name: Install software for 'ansible_next' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_next' }}"
-      run: pip install 'ansible-compat<3' 'ansible${{ inputs.ansible_next_version }}' 'molecule<5' 'molecule-docker==1.1.0' docker netaddr jmespath dnspython 'Jinja2<3.1' 'urllib3<2'
+      run: pip install 'ansible-core${{ inputs.ansible_next_version }}' 'molecule${{ inputs.molecule_version }}' molecule-plugins[docker] docker netaddr jmespath dnspython 'Jinja2${{ inputs.jinja2_version }}'
       shell: bash
 
     - name: Install software for 'ansible_latest' scenario
       if: "${{ inputs.ansible_scenario == 'ansible_latest' }}"
-      run: pip install 'ansible${{ inputs.ansible_version }}' 'molecule${{ inputs.molecule_version }}' molecule-plugins[docker] docker netaddr jmespath dnspython 'Jinja2${{ inputs.jinja2_version }}' 'urllib3<2'
+      run: pip install 'ansible-core${{ inputs.ansible_version }}' 'molecule${{ inputs.molecule_version }}' molecule-plugins[docker] docker netaddr jmespath dnspython 'Jinja2${{ inputs.jinja2_version }}'
       shell: bash
 
     - name: Install software for generic use case
       if: "${{ inputs.ansible_scenario == '' }}"
-      run: pip install 'ansible${{ inputs.ansible_version }}' 'molecule${{ inputs.molecule_version }}' molecule-plugins[docker] docker netaddr jmespath dnspython 'Jinja2${{ inputs.jinja2_version }}' 'urllib3<2'
+      run: pip install 'ansible-core${{ inputs.ansible_version }}' 'molecule${{ inputs.molecule_version }}' molecule-plugins[docker] docker netaddr jmespath dnspython 'Jinja2${{ inputs.jinja2_version }}'
       shell: bash
 
     - name: Pip list

--- a/requirements/collections_ansible_current.yml
+++ b/requirements/collections_ansible_current.yml
@@ -1,30 +1,16 @@
 ---
 collections:
+  - name: amazon.aws
   - name: ansible.netcommon
   - name: ansible.posix
   - name: ansible.utils
-  - name: community.crypto
-  - name: community.rabbitmq
-  # Use amazon.aws 4.x.y if you are using Ansible 2.9 or Ansible Core 2.10.
-  # At least 1.5.0 for 'purge_tags' support / https://github.com/ansible-collections/amazon.aws/issues/229
-  - name: amazon.aws
-    version: 4.4.0
-  # Use community.aws 4.x.y if you are using Ansible 2.9 or Ansible Core 2.10.
-  # community.aws:=4.5.0 needs amazon.aws:=4.4.0  - name: amazon.aws
   - name: community.aws
-    version: 4.5.0
-  # Please note that Ansible 2.9 and ansible-base 2.10 are no longer supported. If you need to use them, use community.docker 2.x.y
+  - name: community.crypto
   - name: community.docker
-    version: 2.7.5
-  # Please use community.general 4.x.y with Ansible 2.9 and ansible-base 2.10
   - name: community.general
-    version: 4.8.11
-  # latest Version tested against MongoDB < 4.4
+  # use an older release of this collection (1.3.4 or earlier) if you're using an old MongoDB version (3.6 or earlier).
   - name: community.mongodb
-    version: 1.2.1
-  # https://github.com/ansible-collections/community.mysql/pull/347
+    version: 1.3.4
   - name: community.mysql
-    version: 1.4.4
-  # https://github.com/ansible-collections/community.postgresql/blob/stable-1/CHANGELOG.rst#v173
   - name: community.postgresql
-    version: 1.7.2
+  - name: community.rabbitmq

--- a/requirements/collections_ansible_latest.yml
+++ b/requirements/collections_ansible_latest.yml
@@ -1,14 +1,14 @@
 ---
 collections:
+  - name: amazon.aws
   - name: ansible.netcommon
   - name: ansible.posix
   - name: ansible.utils
-  - name: community.crypto
-  - name: community.rabbitmq
-  - name: amazon.aws
   - name: community.aws
+  - name: community.crypto
   - name: community.docker
   - name: community.general
   - name: community.mongodb
   - name: community.mysql
   - name: community.postgresql
+  - name: community.rabbitmq

--- a/requirements/collections_ansible_next.yml
+++ b/requirements/collections_ansible_next.yml
@@ -1,30 +1,14 @@
 ---
 collections:
+  - name: amazon.aws
   - name: ansible.netcommon
   - name: ansible.posix
   - name: ansible.utils
-  - name: community.crypto
-  - name: community.rabbitmq
-  # Use amazon.aws 4.x.y if you are using Ansible 2.9 or Ansible Core 2.10.
-  # At least 1.5.0 for 'purge_tags' support / https://github.com/ansible-collections/amazon.aws/issues/229
-  - name: amazon.aws
-    version: 4.4.0
-  # Use community.aws 4.x.y if you are using Ansible 2.9 or Ansible Core 2.10.
-  # community.aws:=4.5.0 needs amazon.aws:=4.4.0  - name: amazon.aws
   - name: community.aws
-    version: 4.5.0
-  # Please note that Ansible 2.9 and ansible-base 2.10 are no longer supported. If you need to use them, use community.docker 2.x.y
+  - name: community.crypto
   - name: community.docker
-    version: 2.7.5
-  # Please use community.general 4.x.y with Ansible 2.9 and ansible-base 2.10
   - name: community.general
-    version: 4.8.11
-  # latest Version tested against MongoDB < 4.4
   - name: community.mongodb
-    version: 1.2.1
-  # https://github.com/ansible-collections/community.mysql/pull/347
   - name: community.mysql
-    version: 1.4.4
-  # https://github.com/ansible-collections/community.postgresql/blob/stable-1/CHANGELOG.rst#v173
   - name: community.postgresql
-    version: 1.7.2
+  - name: community.rabbitmq


### PR DESCRIPTION
- entferne vorherige Pins
- Update Ansible Collection Requirements
- Nuze Jinja2 PIN aus Baseimage für Ansible Current

ℹ️ Ansible >2.13 erfordert Python 3.10, andernfalls schlägt die CI Pipeline fehl